### PR TITLE
Extend pykostal to support multiple dxsIds and restructred response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# VSCode
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Verwendet IntelliSense zum Ermitteln möglicher Attribute.
+  // Zeigen Sie auf vorhandene Attribute, um die zugehörigen Beschreibungen anzuzeigen.
+  // Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Aktuelle Datei",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Python: Aktuelle Datei",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Python module for [Kostal](https://www.kostal-solar-electric.com/) piko inverter
   - day
   - log-data
   - total
+- all settings
 
 not supported:
 
-- all settings
 - events
 
 ongoing:

--- a/example.py
+++ b/example.py
@@ -7,15 +7,19 @@ import aiohttp
 
 import kostal
 
+
 async def main(loop, host):
     async with aiohttp.ClientSession(loop=loop) as session:
         inverter = kostal.Piko(session, host)
 
         res = await inverter.day_yield()
-        print(f'day yield: {res}')
+        print(f"day yield: {res}")
+
+        res = await inverter.get_all()
+        print(f"all entries: {res}")
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(main(loop, 'http://192.168.2.10'))
+    loop.run_until_complete(main(loop, "http://192.168.178.86"))

--- a/example.py
+++ b/example.py
@@ -15,6 +15,9 @@ async def main(loop, host):
         res = await inverter.day_yield()
         print(f"day yield: {res}")
 
+        res = await inverter.get_info_inverter()
+        print(f"all inverter info: {res}")
+
         res = await inverter.get_all()
         print(f"all entries: {res}")
 

--- a/example.py
+++ b/example.py
@@ -18,7 +18,7 @@ async def main(loop, host):
         res = await inverter.get_info_inverter()
         print(f"all inverter info: {res}")
 
-        res = await inverter.get_all()
+        res = await inverter.get_all_entries()
         print(f"all entries: {res}")
 
 

--- a/kostal/__init__.py
+++ b/kostal/__init__.py
@@ -113,13 +113,17 @@ class Piko:
                 ) as resp:
                     assert resp.status == 200
                     return await resp.json(content_type="text/plain")
-        except (asyncio.TimeoutError, aiohttp.ClientError):
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
             raise ConnectionError(
-                "Connection to Kostal device failed at {}.".format(self.__url)
+                "Connection to Kostal device failed at {} with error {}".format(
+                    self.__url, err
+                )
             )
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as err:
             raise ValueError(
-                "Device returned a non-JSON reply at {}.".format(self.__url)
+                "Device returned a non-JSON reply at {} with error {}".format(
+                    self.__url, err
+                )
             )
 
     async def __fetch_dxs_entry(self, entry_ids: []):

--- a/kostal/__init__.py
+++ b/kostal/__init__.py
@@ -124,12 +124,27 @@ class Piko:
 
     async def __fetch_dxs_entry(self, entry_ids: []):
         if len(entry_ids) > 0:
-            request_params = []
-            for i in range(0, len(entry_ids)):
-                request_params.append(("dxsEntries", entry_ids[i]))
-            print(request_params)
-            r = await self.__fetch_data(request_params)
-            return DxsResponse(**r).get_entry_by_id(entry_ids)
+            # Kostal API is only returning max 25 entries - if entry_ids contains more than 25 entries we will split up the request
+            splits = round(len(entry_ids) / 25) + 1
+            dxsEntries_result = {"dxsEntries": [], "session": {}, "status": {}}
+            for i in range(0, splits):
+                request_params = []
+                split_start = i * 25
+                split_end = (i + 1) * 25
+                for k in range(split_start, split_end):
+                    if k < len(entry_ids):
+                        request_params.append(("dxsEntries", entry_ids[k]))
+                        # print(request_params)
+                    else:
+                        break
+                # Check if any request_params (dxsId) is given, otherwise don't call the API
+                if len(request_params) > 0:
+                    r = await self.__fetch_data(request_params)
+                    dxsEntries_result["dxsEntries"].extend(r["dxsEntries"])
+                    dxsEntries_result["session"] = r["session"]
+                    dxsEntries_result["status"] = r["status"]
+
+            return DxsResponse(**dxsEntries_result).get_entry_by_id(entry_ids)
 
     def __generate_query_results(self, dxs_entries, query_object):
         query_results = {}
@@ -177,6 +192,7 @@ class Piko:
         return query_result
 
     async def get_all(self):
+        # Build List of elements that should be queried. This will be the structure for the response
         query_elements = {
             "ActualAnalogInputs": const.ActualAnalogInputs,
             "ActualBattery": const.ActualBattery,
@@ -186,12 +202,120 @@ class Piko:
             "ActualSZeroIn": const.ActualSZeroIn,
             "Home": const.Home,
             "InfoVersions": const.InfoVersions,
+            "InfoInverter": const.InfoInverter,
             "StatisticDay": const.StatisticDay,
             "StatisticTotal": const.StatisticTotal,
         }
-        print(query_elements)
-        # print(list(map(operator.itemgetter("dxsId"), query_elements)))
-        # entry_ids = list(map(operator.itemgetter("dxsId"), query_elements))
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_actual_analog_inputs(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "ActualAnalogInputs": const.ActualAnalogInputs,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_actual_battery(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "ActualBattery": const.ActualBattery,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_actual_grid(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "ActualGrid": const.ActualGrid,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_actual_house(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "ActualHouse": const.ActualHouse,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_actual_pv_generator(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "ActualPVGenerator": const.ActualPVGenerator,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_actual_szero_in(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "ActualSZeroIn": const.ActualSZeroIn,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_actual_home(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "Home": const.Home,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_info_versions(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "InfoVersions": const.InfoVersions,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_info_inverter(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "InfoInverter": const.InfoInverter,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_statistic_day(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "StatisticDay": const.StatisticDay,
+        }
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_statistic_total(self):
+        # Build List of elements that should be queried. This will be the structure for the response
+        query_elements = {
+            "StatisticTotal": const.StatisticTotal,
+        }
         entry_ids = self.__get_all_dxsIds(query_elements)
         dxs_entries = await self.__fetch_dxs_entry(entry_ids)
         query_result = self.__generate_query_results(dxs_entries, query_elements)

--- a/kostal/__init__.py
+++ b/kostal/__init__.py
@@ -6,14 +6,15 @@ import aiohttp
 import async_timeout
 import asyncio
 import json
+import operator
 
 from kostal import const
 
 DXS_ENDPOINT = "/api/dxs.json"
 LOG_DATA_ENDPOINT = "/LogDaten.dat"
 
-DEFAULT_USERNAME = 'pvserver'
-DEFAULT_PASSWORD = 'pvwr'
+DEFAULT_USERNAME = "pvserver"
+DEFAULT_PASSWORD = "pvwr"
 
 
 class DxsEntry:
@@ -59,11 +60,12 @@ class DxsResponse:
         self.__session = DxsSessionData.from_json(session)
         self.status = DxsStatus.from_json(status)
 
-    def get_entry_by_id(self, dxs_id: int):
+    def get_entry_by_id(self, dxs_id: []):
+        entries_by_id = []
         for i in self.__dxs_entries:
-            if i.dxsId == dxs_id:
-                return i
-        return None
+            if i.dxsId in dxs_id:
+                entries_by_id.append(i)
+        return entries_by_id
 
     @classmethod
     def from_json(cls, json_str):
@@ -72,7 +74,7 @@ class DxsResponse:
 
 
 class Piko:
-    """ 
+    """
     Interface to communicate with the Kostal Piko over http request
     Attributes:
         session     The AIO session
@@ -81,12 +83,17 @@ class Piko:
         username    inverter username (default pvserver)
         password    inverter password (default pvwr)
         timeout     HTTP timeout in seconds
-     """
+    """
 
-    def __init__(self, session: aiohttp.ClientSession, url: str = None, username: str = DEFAULT_USERNAME,
-                 password: str = DEFAULT_PASSWORD,
-                 timeout: int = 10):
-        """ Constructor """
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        url: str = None,
+        username: str = DEFAULT_USERNAME,
+        password: str = DEFAULT_PASSWORD,
+        timeout: int = 10,
+    ):
+        """Constructor"""
         if url is None:
             raise ValueError("Parameter url can not be None")
 
@@ -97,27 +104,95 @@ class Piko:
         self.__timeout = timeout
 
     async def __fetch_data(self, request_params):
-        """ fetch data """
-        auth=aiohttp.BasicAuth(self.__username, self.__password)
+        """fetch data"""
+        auth = aiohttp.BasicAuth(self.__username, self.__password)
         try:
             async with async_timeout.timeout(self.__timeout):
-                async with self.__client.get(self.__url,
-                                             params=request_params,
-                                             auth=auth,
-                                             timeout=self.__timeout) as resp:
+                async with self.__client.get(
+                    self.__url, params=request_params, auth=auth, timeout=self.__timeout
+                ) as resp:
                     assert resp.status == 200
-                    return await resp.json(content_type='text/plain')
+                    return await resp.json(content_type="text/plain")
         except (asyncio.TimeoutError, aiohttp.ClientError):
             raise ConnectionError(
-                "Connection to Kostal device failed at {}.".format(self.__url))
+                "Connection to Kostal device failed at {}.".format(self.__url)
+            )
         except json.JSONDecodeError:
             raise ValueError(
-                "Device returned a non-JSON reply at {}.".format(self.__url))
+                "Device returned a non-JSON reply at {}.".format(self.__url)
+            )
 
-    async def __fetch_dxs_entry(self, entry_id: []):
-        r = await self.__fetch_data({'dxsEntries': entry_id})
-        return DxsResponse(**r).get_entry_by_id(entry_id)
+    async def __fetch_dxs_entry(self, entry_ids: []):
+        if len(entry_ids) > 0:
+            request_params = []
+            for i in range(0, len(entry_ids)):
+                request_params.append(("dxsEntries", entry_ids[i]))
+            print(request_params)
+            r = await self.__fetch_data(request_params)
+            return DxsResponse(**r).get_entry_by_id(entry_ids)
+
+    def __generate_query_results(self, dxs_entries, query_object):
+        query_results = {}
+        found_matching_entry = False
+        for dxs_entry in dxs_entries:
+            print("Searching for ", dxs_entry.dxsId)
+            for groupname, group_dxs_entries in query_object.items():
+                print("Checking ", groupname)
+                for (
+                    query_dxs_entryname,
+                    query_dxs_entryvalues,
+                ) in group_dxs_entries.items():
+                    if query_dxs_entryvalues["dxsId"] == dxs_entry.dxsId:
+                        query_dxs_entryvalues["value"] = dxs_entry.value
+                        if not groupname in query_results:
+                            query_results.update({groupname: {}})
+                        query_results[groupname].update(
+                            {query_dxs_entryname: query_dxs_entryvalues}
+                        )
+                        found_matching_entry = True
+                        print("Found Matching entry for ", query_dxs_entryvalues)
+                        break
+
+                if found_matching_entry:
+                    found_matching_entry = False
+                    break
+        print(query_results)
+        return query_results
+
+    def __get_all_dxsIds(self, query_elements):
+        dxsIds = []
+        found_matching_entry = False
+        for group in query_elements.values():
+            for query_dxs_entryvalues in group.values():
+                print("Checking ", query_dxs_entryvalues)
+                dxsIds.append(query_dxs_entryvalues["dxsId"])
+        print(dxsIds)
+        return dxsIds
 
     async def day_yield(self):
-        entry = await self.__fetch_dxs_entry(const.StatisticDay['Yield'])
-        return entry.value
+        query_elements = {"StatisticDay": const.StatisticDay}
+        entry_ids = [query_elements["StatisticDay"]["Yield"]["dxsId"]]
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result
+
+    async def get_all(self):
+        query_elements = {
+            "ActualAnalogInputs": const.ActualAnalogInputs,
+            "ActualBattery": const.ActualBattery,
+            "ActualGrid": const.ActualGrid,
+            "ActualHouse": const.ActualHouse,
+            "ActualPVGenerator": const.ActualPVGenerator,
+            "ActualSZeroIn": const.ActualSZeroIn,
+            "Home": const.Home,
+            "InfoVersions": const.InfoVersions,
+            "StatisticDay": const.StatisticDay,
+            "StatisticTotal": const.StatisticTotal,
+        }
+        print(query_elements)
+        # print(list(map(operator.itemgetter("dxsId"), query_elements)))
+        # entry_ids = list(map(operator.itemgetter("dxsId"), query_elements))
+        entry_ids = self.__get_all_dxsIds(query_elements)
+        dxs_entries = await self.__fetch_dxs_entry(entry_ids)
+        query_result = self.__generate_query_results(dxs_entries, query_elements)
+        return query_result

--- a/kostal/__init__.py
+++ b/kostal/__init__.py
@@ -190,7 +190,7 @@ class Piko:
         query_result = self.__generate_query_results(dxs_entries, query_elements)
         return query_result
 
-    async def get_all(self):
+    async def get_all_entries(self):
         # Build List of elements that should be queried. This will be the structure for the response
         query_elements = {
             "ActualAnalogInputs": const.ActualAnalogInputs,

--- a/kostal/const.py
+++ b/kostal/const.py
@@ -82,6 +82,12 @@ InfoVersions = {
     "CountrySettingsVersion": {"dxsId": 16779521, "unit": ""},
 }
 
+InfoInverter = {
+    "Unknown": {"dxsId": 16780288, "unit": ""},
+    "InverterName": {"dxsId": 16777984, "unit": ""},
+    "InverterType": {"dxsId": 16780544, "unit": ""},
+}
+
 StatisticDay = {
     "Yield": {"dxsId": 251658754, "unit": "Wh"},
     "HomeConsumption": {"dxsId": 251659010, "unit": "Wh"},

--- a/kostal/const.py
+++ b/kostal/const.py
@@ -1,96 +1,100 @@
 #!/usr/bin/env python3
 
 ActualAnalogInputs = {
-    'Analog1': 167772417,
-    'Analog2': 167772673,
-    'Analog3': 167772929,
-    'Analog4': 167773185,
+    "Analog1": {"dxsId": 167772417, "unit": "V"},
+    "Analog2": {"dxsId": 167772673, "unit": "V"},
+    "Analog3": {"dxsId": 167772929, "unit": "V"},
+    "Analog4": {"dxsId": 167773185, "unit": "V"},
 }
 
 ActualBattery = {
-    'Voltage': 33556226,
-    'Charge': 33556229,
-    'Current': 33556238,
-    'CurrentDir': 33556230,
-    'ChargeCycles': 33556228,
-    'Temperature': 33556227,
+    "Voltage": {"dxsId": 33556226, "unit": "V"},
+    "Charge": {"dxsId": 33556229, "unit": "%"},
+    "Current": {"dxsId": 33556238, "unit": "A"},
+    "BatteryStatus": {"dxsId": 33556230, "unit": ""},
+    "ChargeCycles": {"dxsId": 33556228, "unit": ""},
+    "Temperature": {"dxsId": 33556227, "unit": "°C"},
 }
+
+BatteryStatusCodes = {0: "Charging", 1: "Discharging"}
 
 ActualGrid = {
-    'GridOutputPower': 67109120,
-    'GridFreq': 67110400,
-    'GridCosPhi': 67110656,
-    'GridLimitation': 67110144,
-    'GridVoltageL1': 67109378,
-    'GridCurrentL1': 67109377,
-    'GridPowerL1': 67109379,
-    'GridVoltageL2': 67109634,
-    'GridCurrentL2': 67109633,
-    'GridPowerL2': 67109635,
-    'GridVoltageL3': 67109890,
-    'GridCurrentL3': 67109889,
-    'GridPowerL3': 67109891,
+    "GridOutputPower": {"dxsId": 67109120, "unit": "W"},
+    "GridFreq": {"dxsId": 67110400, "unit": "Hz"},
+    "GridCosPhi": {"dxsId": 67110656, "unit": ""},
+    "GridLimitation": {"dxsId": 67110144, "unit": "%"},
+    "GridVoltageL1": {"dxsId": 67109378, "unit": "V"},
+    "GridCurrentL1": {"dxsId": 67109377, "unit": "A"},
+    "GridPowerL1": {"dxsId": 67109379, "unit": "W"},
+    "GridVoltageL2": {"dxsId": 67109634, "unit": "V"},
+    "GridCurrentL2": {"dxsId": 67109633, "unit": "A"},
+    "GridPowerL2": {"dxsId": 67109635, "unit": "W"},
+    "GridVoltageL3": {"dxsId": 67109890, "unit": "V"},
+    "GridCurrentL3": {"dxsId": 67109889, "unit": "A"},
+    "GridPowerL3": {"dxsId": 67109891, "unit": "W"},
 }
 
-ActualHome = {
-    'AktHomeConsumptionSolar': 83886336,
-    'AktHomeConsumptionBat': 83886592,
-    'AktHomeConsumptionGrid': 83886848,
-    'PhaseSelHomeConsumpL1': 83887106,
-    'PhaseSelHomeConsumpL2': 83887362,
-    'PhaseSelHomeConsumpL3': 83887618,
+ActualHouse = {
+    "ActHomeConsumptionSolar": {"dxsId": 83886336, "unit": "W"},
+    "ActHomeConsumptionBat": {"dxsId": 83886592, "unit": "W"},
+    "ActHomeConsumptionGrid": {"dxsId": 83886848, "unit": "W"},
+    "PhaseSelHomeConsumpL1": {"dxsId": 83887106, "unit": "W"},
+    "PhaseSelHomeConsumpL2": {"dxsId": 83887362, "unit": "W"},
+    "PhaseSelHomeConsumpL3": {"dxsId": 83887618, "unit": "W"},
 }
 
-ActualGenerator = {
-    'dc1Voltage': 33555202,
-    'dc1Current': 33555201,
-    'dc1Power': 33555203,
-    'dc2Voltage': 33555458,
-    'dc2Current': 33555457,
-    'dc2Power': 33555459,
-    'dc3Voltage': 33555714,
-    'dc3Current': 33555713,
-    'dc3Power': 33555715,
+ActualPVGenerator = {
+    "dc1Voltage": {"dxsId": 33555202, "unit": "V"},
+    "dc1Current": {"dxsId": 33555201, "unit": "A"},
+    "dc1Power": {"dxsId": 33555203, "unit": "W"},
+    "dc2Voltage": {"dxsId": 33555458, "unit": "V"},
+    "dc2Current": {"dxsId": 33555457, "unit": "A"},
+    "dc2Power": {"dxsId": 33555459, "unit": "W"},
+    "dc3Voltage": {"dxsId": 33555714, "unit": "V"},
+    "dc3Current": {"dxsId": 33555713, "unit": "A"},
+    "dc3Power": {"dxsId": 33555715, "unit": "W"},
 }
 
 ActualSZeroIn = {
-    'S0InPulseCnt': 184549632,
-    'Loginterval': 150995968,
+    "S0InPulseCnt": {"dxsId": 184549632, "unit": ""},
+    "Loginterval": {"dxsId": 150995968, "unit": "s"},
 }
 
 Home = {
-    'dcPowerPV': 33556736,
-    'acPower': 67109120,
-    'ownConsumption': 83888128,
-    'batStateOfCharge': 33556229,
+    "dcPowerPV": {"dxsId": 33556736, "unit": "W"},
+    "acPower": {"dxsId": 67109120, "unit": "W"},
+    "selfConsumption": {"dxsId": 83888128, "unit": "W"},
+    "batStateOfCharge": {"dxsId": 33556229, "unit": "%"},
     # TODO: statusCodes
-    'operatingStatus': 16780032,
+    "operatingStatus": {"dxsId": 16780032, "unit": ""},
 }
 
+OperatingStatusCodes = {0: "0", 1: "1", 2: "Starting", 3: "Feed In"}
+
 InfoVersions = {
-    'VersionUI': 16779267,
-    'VersionFW': 16779265,
-    'VersionHW': 16779266,
-    'VersionPAR': 16779268,
-    'SerialNumber': 16777728,
-    'ArticleNumber': 16777472,
-    'CountrySettingsName': 16779522,
-    'CountrySettingsVersion': 16779521,
+    "VersionUI": {"dxsId": 16779267, "unit": ""},
+    "VersionFW": {"dxsId": 16779265, "unit": ""},
+    "VersionHW": {"dxsId": 16779266, "unit": ""},
+    "VersionPAR": {"dxsId": 16779268, "unit": ""},
+    "SerialNumber": {"dxsId": 16777728, "unit": ""},
+    "ArticleNumber": {"dxsId": 16777472, "unit": ""},
+    "CountrySettingsName": {"dxsId": 16779522, "unit": ""},
+    "CountrySettingsVersion": {"dxsId": 16779521, "unit": ""},
 }
 
 StatisticDay = {
-    'Yield': 251658754,
-    'HomeConsumption': 251659010,
-    'OwnConsumption': 251659266,
-    'OwnConsRate': 251659278,
-    'AutonomyDegree': 251659279,
+    "Yield": {"dxsId": 251658754, "unit": "Wh"},
+    "HomeConsumption": {"dxsId": 251659010, "unit": "Wh"},
+    "SelfConsumption": {"dxsId": 251659266, "unit": "Wh"},
+    "SelfConsRate": {"dxsId": 251659278, "unit": "%"},
+    "AutonomyDegree": {"dxsId": 251659279, "unit": "%"},
 }
 
 StatisticTotal = {
-    'Yield': 251658753,
-    'OperatingTime': 251658496,
-    'HomeConsumption': 251659009,
-    'OwnConsumption': 251659265,
-    'OwnConsRate': 251659280,
-    'AutonomyDegree': 251659281,
+    "Yield": {"dxsId": 251658753, "unit": "Wh"},
+    "OperatingTime": {"dxsId": 251658496, "unit": "h"},
+    "HomeConsumption": {"dxsId": 251659009, "unit": "Wh"},
+    "SelfConsumption": {"dxsId": 251659265, "unit": "Wh"},
+    "SelfConsRate": {"dxsId": 251659280, "unit": "%"},
+    "AutonomyDegree": {"dxsId": 251659281, "unit": "%"},
 }

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pykostal",
-    version="0.0.1",
+    version="0.0.2",
     author="Andreas Rehn",
     author_email="rehn.andreas86@gmail.com",
     url="https://github.com/DAMEK86/pykostal",

--- a/setup.py
+++ b/setup.py
@@ -4,33 +4,30 @@
 from setuptools import setup, find_packages
 
 # Get the long description from the README file
-with open('README.md', 'r') as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='pykostal',
-    version='0.0.1',
-    author='Andreas Rehn',
-    author_email='rehn.andreas86@gmail.com',
-    url='https://github.com/DAMEK86/pykostal',
-    description='package to communicate with Kostal Piko invertes',
+    name="pykostal",
+    version="0.0.1",
+    author="Andreas Rehn",
+    author_email="rehn.andreas86@gmail.com",
+    url="https://github.com/DAMEK86/pykostal",
+    description="package to communicate with Kostal Piko invertes",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    py_modules=['kostal'],
+    long_description_content_type="text/markdown",
+    py_modules=["kostal"],
     packages=find_packages(),
-    license='MIT',
+    license="MIT",
     classifiers=[
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
     ],
-    python_requires='>=3',
-    install_requires=[
-        'async_timeout',
-        'aiohttp'
-    ],
+    python_requires=">=3",
+    install_requires=["async_timeout", "aiohttp"],
     extras_require={
         "dev": [
             "pytest>=3.7",


### PR DESCRIPTION
- Added unit to const data structure
- Use const data structure as return data structure
- Support for multiple entry queries
- Extended the request parameter generation to allow querying of multiple dxsIDs
- Added result query generation to return only queried values
ToDo:
- Adding work around to overcome the 25 entries limit of the Kostal API